### PR TITLE
add Windows support

### DIFF
--- a/src/helpers/stringHelpers.ts
+++ b/src/helpers/stringHelpers.ts
@@ -1,9 +1,9 @@
+import { dirname } from "path";
+
 export const removeFirstAndLastCharacter = (str: string): string => str.slice(1, -1);
 
 export const removeLastDirectoryInURL = (path: string): string => {
-    const pathParts = path.split("/");
-    pathParts.pop();
-    return pathParts.join("/");
+    return dirname(path);
 };
 
 export const removeNewLine = (string: string): string => {


### PR DESCRIPTION
Close #3

Add Windows support by:
- replacing the usage of `cut` and `awk` commands with javascript implementation.
- use node.js `path` module to deal with directory separator related maniuplation.