### PR TITLE
feat(worktree-checkout): validate branch name format before checkout

### DIFF
--- a/src/git/operations/worktree/gitWorktreeAdd.ts
+++ b/src/git/operations/worktree/gitWorktreeAdd.ts
@@ -43,6 +43,10 @@ const gitWorktreeAdd = async (): Promise<void> => {
 
         // we need to check if the user's input value is a valid git branch name
         const branchNameValidateInput: InputBoxOptions["validateInput"] = async (value: string) => {
+            // we allow user input an empty string here,
+            // because we will assign the remote branch as the new branch later if the input is an empty string
+            if (value === "") return "";
+
             if (await isBranchNameValid(value)) return "";
 
             return `fatal: '${value}' is not a valid branch name`;

--- a/src/git/operations/worktree/gitWorktreeAdd.ts
+++ b/src/git/operations/worktree/gitWorktreeAdd.ts
@@ -1,3 +1,4 @@
+import type { InputBoxOptions } from "vscode";
 import {
     addNewWorktree,
     addRemoteWorktree,
@@ -10,6 +11,7 @@ import {
     isGitRepository,
     getRemoteBranches,
     removeLocalBranchesThatDoNotExistOnRemoteRepository,
+    isBranchNameValid,
 } from "../../../helpers/gitHelpers";
 import {
     copyToClipboard,
@@ -39,7 +41,17 @@ const gitWorktreeAdd = async (): Promise<void> => {
         const remoteBranch = await selectBranch(remoteBranches);
         if (!remoteBranch) return;
 
-        let newBranch = await getUserInput("New branch", "Type the name of the new branch");
+        // we need to check if the user's input value is a valid git branch name
+        const branchNameValidateInput: InputBoxOptions["validateInput"] = async (value: string) => {
+            if (await isBranchNameValid(value)) return "";
+
+            return `fatal: '${value}' is not a valid branch name`;
+        };
+        let newBranch = await getUserInput(
+            "New branch",
+            "Type the name of the new branch",
+            branchNameValidateInput
+        );
 
         // if the user didn't select a branch, we assign the remote branch as the new branch
         if (!newBranch) {

--- a/src/helpers/gitHelpers.ts
+++ b/src/helpers/gitHelpers.ts
@@ -139,3 +139,18 @@ export const removeLocalBranchesThatDoNotExistOnRemoteRepository = async () => {
         throw Error(e);
     }
 };
+
+/**
+ * use `git check-ref-format` command to check if a given string is a valid branch name.
+ * see https://git-scm.com/docs/git-check-ref-format for more details.
+ */
+export const isBranchNameValid = async (branchName: string): Promise<boolean> => {
+    try {
+        const isBranchNameValidCommand = `git check-ref-format --branch "${branchName}"`;
+        await executeCommand(isBranchNameValidCommand);
+
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/helpers/vsCodeHelpers.ts
+++ b/src/helpers/vsCodeHelpers.ts
@@ -18,10 +18,15 @@ export const showInformationMessageWithButton = async (
 ): Promise<string | undefined> =>
     await vscode.window.showInformationMessage(`${APP_NAME}: ${informationMessage}`, buttonName);
 
-export const getUserInput = async (placeHolder: string, prompt: string) => {
+export const getUserInput = async (
+    placeHolder: string,
+    prompt: string,
+    validateInput?: vscode.InputBoxOptions["validateInput"]
+) => {
     const input = await vscode.window.showInputBox({
         placeHolder,
         prompt,
+        validateInput,
     });
 
     return input;


### PR DESCRIPTION
Related to #22

- Add a way to check if the user input is a valid git branch name
- If the branch name is invalid, the error message will show up:

![image](https://user-images.githubusercontent.com/16042676/206827195-93ab33e2-3577-4b04-b8c0-5513adcf4642.png)