### PR TITLE
fix: use `child_process.spawn` to better handle whitespace in command

### DIFF
--- a/src/helpers/gitHelpers.ts
+++ b/src/helpers/gitHelpers.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { executeCommand } from "./helpers";
+import { executeCommand, spawnCommand } from "./helpers";
 import { removeNewLine } from "./stringHelpers";
 import { getWorktrees } from "./gitWorktreeHelpers";
 import { BARE_REPOSITORY, BARE_REPOSITORY_REMOTE_ORIGIN_FETCH } from "../constants/constants";
@@ -65,8 +65,11 @@ export const getRemoteBranches = async (workspaceFolder: string): Promise<string
 
 export const isBareRepository = async (workspaceFolder: string, path: string) => {
     try {
-        const isBareRepositoryCommand = `git -C ${path} rev-parse --is-bare-repository`;
-        const { stdout } = await executeCommand(isBareRepositoryCommand, { cwd: workspaceFolder });
+        const { stdout } = await spawnCommand(
+            "git",
+            ["-C", path, "rev-parse", "--is-bare-repository"],
+            { cwd: workspaceFolder }
+        );
 
         const isBareRepo = removeNewLine(stdout);
 

--- a/src/helpers/gitWorktreeHelpers.ts
+++ b/src/helpers/gitWorktreeHelpers.ts
@@ -9,7 +9,6 @@ import {
 import { existsRemoteBranch, isBareRepository } from "./gitHelpers";
 import { MAIN_WORKTREES } from "../constants/constants";
 import {
-    escapeSpaces,
     getFileFromPath,
     removeFirstAndLastCharacter,
     removeLastDirectoryInURL,
@@ -270,7 +269,6 @@ export const calculateNewWorktreePath = async (workspaceFolder: string, branch: 
 
         const gitCommonDirPath = await getGitCommonDirPath(workspaceFolder);
         let path = removeNewLine(gitCommonDirPath);
-        path = escapeSpaces(path);
 
         const isBareRepo = await isBareRepository(workspaceFolder, path);
 

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,5 +1,6 @@
 import * as util from "util";
 import * as vscode from "vscode";
+import { SpawnOptionsWithoutStdio, spawn } from "child_process";
 import { EXTENSION_ID, DEMO_URL } from "../constants/constants";
 import { showInformationMessageWithButton } from "./vsCodeHelpers";
 
@@ -38,6 +39,40 @@ export const executeCommand = async (
         const errorMessage = `command: '${command}'. error: '${e.message}'`;
         throw Error(errorMessage);
     }
+};
+
+// modified from https://stackoverflow.com/a/67379845/9979122
+export const spawnCommand = async (
+    command: string,
+    args?: string[],
+    options?: SpawnOptionsWithoutStdio
+) => {
+    return new Promise<{ stdout: string }>((resolve, reject) => {
+        const stdoutChunks: Buffer[] = [];
+        const stderrChunks: Buffer[] = [];
+
+        const subprocess = spawn(command, args, options);
+
+        subprocess.stdout.on("data", (chunk) => {
+            stdoutChunks.push(chunk);
+        });
+
+        subprocess.stderr.on("data", (chunk) => {
+            stderrChunks.push(chunk);
+        });
+
+        subprocess.on("error", (error) => {
+            reject(error);
+        });
+
+        subprocess.on("exit", (code) => {
+            if (code !== 0) {
+                reject(Buffer.concat(stderrChunks).toString());
+            }
+
+            resolve({ stdout: Buffer.concat(stdoutChunks).toString() });
+        });
+    });
 };
 
 export const isMajorUpdate = (previousVersion: string, currentVersion: string) => {


### PR DESCRIPTION
Closes #26

- Replace `child_process.exec` with `child_process.spawn` to better handle whitespace in command.
    - `child_process.spawn` will handle the character escaping for us, and it works seamlessly across all major OS.
- Add `spawnCommand` helper function
    - It converts `child_process.spawn` to a Promise based API with input/output behavior similar to `executeCommand` helper function.
    - The implementation is modified from this stackover answer: https://stackoverflow.com/a/67379845/9979122.