### PR TITLE
feat: add path variable support for worktree directory configuration …

### DIFF
--- a/.worktree.yml.example
+++ b/.worktree.yml.example
@@ -1,0 +1,24 @@
+# .worktree.yml - Lifecycle hooks for git worktree operations
+#
+# Supported variables in commands:
+#   ${userHome}                - User home directory
+#   ${workspaceFolder}         - Full path of the worktree
+#   ${workspaceFolderBasename} - Folder name of the worktree
+#   ${repositoryName}          - Name of the origin repository
+
+add:
+  copy:
+    - .env
+    - .env.local
+  commands:
+    - yarn install
+    - yarn db:generate
+    - tmux has-session -t ${repositoryName} 2>/dev/null && tmux new-window -t ${repositoryName} -n ${workspaceFolderBasename} -c ${workspaceFolder} || tmux new-session -d -s ${repositoryName} -n ${workspaceFolderBasename} -c ${workspaceFolder}
+
+switch:
+  commands:
+    - tmux has-session -t ${repositoryName} 2>/dev/null && tmux new-window -t ${repositoryName} -n ${workspaceFolderBasename} -c ${workspaceFolder} || tmux new-session -d -s ${repositoryName} -n ${workspaceFolderBasename} -c ${workspaceFolder}
+
+remove:
+  commands:
+    - tmux kill-window -t ${repositoryName}:${workspaceFolderBasename} 2>/dev/null || true

--- a/__mocks__/vscode.js
+++ b/__mocks__/vscode.js
@@ -2,12 +2,18 @@ const vscode = {
     window: {
         showInformationMessage: jest.fn(),
         showErrorMessage: jest.fn(),
+        showWarningMessage: jest.fn(),
         createOutputChannel: jest.fn(() => ({
             appendLine: jest.fn(),
             clear: jest.fn(),
             show: jest.fn(),
             dispose: jest.fn(),
         })),
+        withProgress: jest.fn((options, task) => {
+            const progress = { report: jest.fn() };
+            const token = { isCancellationRequested: false };
+            return task(progress, token);
+        }),
     },
     workspace: {
         workspaceFolders: [],
@@ -15,6 +21,9 @@ const vscode = {
             get: jest.fn(),
             update: jest.fn(),
         })),
+    },
+    ProgressLocation: {
+        Notification: 15,
     },
 };
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
                     "vsCodeGitWorktrees.worktrees.dir.path": {
                         "type": "string",
                         "default": null,
-                        "description": "Define a directory for all worktrees between your projects"
+                        "description": "Define a directory for all worktrees. Supports variables: ${userHome}, ${workspaceFolder}, ${workspaceFolderBasename}, ${repositoryName}. Examples: ${userHome}/worktrees/${repositoryName} or ../${workspaceFolderBasename}_worktree"
                     }
                 }
             },

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
         "@semantic-release/github": "^8.0.7",
         "@types/glob": "^7.2.0",
         "@types/jest": "^28.1.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^9.1.0",
         "@types/node": "14.x",
         "@types/vscode": "^1.65.0",
@@ -190,5 +191,8 @@
         "hooks": {
             "pre-commit": "yarn lint-staged"
         }
+    },
+    "dependencies": {
+        "js-yaml": "^4.1.1"
     }
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -12,3 +12,7 @@ export const EXTENSION_ID = "gitworktrees.git-worktrees";
 
 export const DEMO_URL =
     "https://github.com/alexiszamanidis/vscode-git-worktrees#-features--operations";
+
+// Special key to replace forward slashes in branch names for filesystem paths
+// e.g., "feat/abc" becomes "feat__abc"
+export const BRANCH_SLASH_REPLACEMENT = "__";

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -16,3 +16,5 @@ export const DEMO_URL =
 // Special key to replace forward slashes in branch names for filesystem paths
 // e.g., "feat/abc" becomes "feat__abc"
 export const BRANCH_SLASH_REPLACEMENT = "__";
+
+export const WORKTREE_CONFIG_FILENAME = ".worktree.yml";

--- a/src/git/operations/worktree/gitWorktreeList.ts
+++ b/src/git/operations/worktree/gitWorktreeList.ts
@@ -3,6 +3,7 @@ import { isGitRepository } from "../../../helpers/gitHelpers";
 import { copyToClipboard, openBrowser } from "../../../helpers/helpers";
 import { getWorkspaceFolder, showErrorMessageWithButton } from "../../../helpers/vsCodeHelpers";
 import { moveIntoWorktree, getWorktree } from "../../../helpers/gitWorktreeHelpers";
+import { executeWorktreeSwitchHooks } from "../../../helpers/worktree-init-helpers";
 import logger from "../../../helpers/logger";
 
 const gitWorktreeList = async (): Promise<void> => {
@@ -30,6 +31,12 @@ const gitWorktreeList = async (): Promise<void> => {
         if (!worktree) {
             logger.warn("No worktree found.");
             return;
+        }
+
+        try {
+            await executeWorktreeSwitchHooks(workspaceFolder, worktree.detail);
+        } catch (e: any) {
+            logger.warn(`Worktree switch hooks failed, continuing: ${e.message}`);
         }
 
         logger.info("Moving into worktree...");

--- a/src/helpers/gitWorktreeHelpers.ts
+++ b/src/helpers/gitWorktreeHelpers.ts
@@ -22,6 +22,7 @@ import {
     removeNewLine,
 } from "../helpers/stringHelpers";
 import { showInformationMessage, showInformationMessageWithButton } from "./vsCodeHelpers";
+import { executeWorktreeAddHooks, executeWorktreeRemoveHooks } from "./worktree-init-helpers";
 
 type FilteredWorktree = [string, string, string];
 type Worktree = { path: string; hash: string; worktree: string };
@@ -222,7 +223,7 @@ export const findDefaultWorktreeToMove = async (
 export const removeWorktree = async (workspaceFolder: string, worktree: SelectedWorktree) => {
     const isSamePath = workspaceFolder === worktree.detail;
     const worktreePath = worktree.detail;
-    const removeWorktreeCommand = `git worktree remove ${worktreePath}`;
+    const removeWorktreeCommand = `git worktree remove -f ${worktreePath}`;
 
     logger.debug(`Attempting to remove worktree '${worktreePath}' in folder: ${workspaceFolder}`);
 
@@ -234,47 +235,19 @@ export const removeWorktree = async (workspaceFolder: string, worktree: Selected
     }
 
     try {
+        try {
+            await executeWorktreeRemoveHooks(workspaceFolder, worktreePath);
+        } catch (e: any) {
+            logger.warn(`Worktree remove hooks failed, continuing: ${e.message}`);
+        }
+
         logger.debug(`Running command: ${removeWorktreeCommand}`);
         await executeCommand(removeWorktreeCommand, { cwd: workspaceFolder });
         logger.info(`Successfully removed worktree '${worktreePath}'. Pruning worktrees...`);
         await pruneWorktrees(workspaceFolder);
     } catch (e: any) {
-        const errorMessage = e.message;
-        logger.warn(`Failed to remove worktree '${worktreePath}': ${errorMessage}`);
-
-        const untrackedOrModifiedFilesError = `Command failed: git worktree remove ${worktreePath}\nfatal: '${worktreePath}' contains modified or untracked files, use --force to delete it\n`;
-        const isUntrackedOrModifiedFilesError = errorMessage === untrackedOrModifiedFilesError;
-
-        if (!isUntrackedOrModifiedFilesError) {
-            logger.error(
-                `Unexpected error when removing worktree '${worktreePath}': ${errorMessage}`
-            );
-            throw e;
-        }
-
-        const buttonName = "Force Delete";
-        const userMessage = `fatal: '${worktreePath}' contains modified or untracked files, use --force to delete it. Click '${buttonName}' to delete the worktree.`;
-        logger.info(`Prompting user to force delete worktree '${worktreePath}'.`);
-
-        const answer = await showInformationMessageWithButton(userMessage, buttonName);
-
-        if (answer !== buttonName) {
-            logger.info(`User declined to force delete worktree '${worktreePath}'.`);
-            return;
-        }
-
-        const forceRemoveWorktreeCommand = `git worktree remove -f ${worktreePath}`;
-        try {
-            logger.debug(`Running force delete command: ${forceRemoveWorktreeCommand}`);
-            await executeCommand(forceRemoveWorktreeCommand, { cwd: workspaceFolder });
-            logger.info(
-                `Successfully force removed worktree '${worktreePath}'. Pruning worktrees...`
-            );
-            await pruneWorktrees(workspaceFolder);
-        } catch (err: any) {
-            logger.error(`Failed to force remove worktree '${worktreePath}': ${err.message}`);
-            throw err;
-        }
+        logger.error(`Failed to remove worktree '${worktreePath}': ${e.message}`);
+        throw e;
     }
 };
 
@@ -483,6 +456,15 @@ export const addWorktreePostTasks = async (
 
     logger.debug(`Copying worktree files from '${workspaceFolder}' to '${newWorktreePath}'`);
     await copyWorktreeFiles(workspaceFolder, newWorktreePath);
+
+    try {
+        await executeWorktreeAddHooks(workspaceFolder, newWorktreePath);
+    } catch (e: any) {
+        logger.warn(`Worktree add hooks failed, continuing: ${e.message}`);
+        vscode.window.showWarningMessage(
+            `Worktree add hooks failed: ${e.message}. The worktree was still created.`
+        );
+    }
 
     const newWtInfo = await moveIntoWorktree(workspaceFolder, newWorktreePath);
 

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -6,7 +6,7 @@ import { promisify } from "util";
 import { pipeline as pipelineCallback } from "stream";
 
 import { SpawnOptionsWithoutStdio, spawn } from "child_process";
-import { EXTENSION_ID, DEMO_URL } from "../constants/constants";
+import { EXTENSION_ID, DEMO_URL, BRANCH_SLASH_REPLACEMENT } from "../constants/constants";
 import { showInformationMessageWithButton } from "./vsCodeHelpers";
 import { createReadStream, createWriteStream, promises } from "fs";
 
@@ -229,3 +229,56 @@ export const worktreeCopyExcludePatterns = vscode.workspace
 export const worktreeSearchPath: string | null = vscode.workspace
     .getConfiguration()
     .get<string | null>("vsCodeGitWorktrees.worktreeSearchPath", null);
+
+/**
+ * Resolves VS Code-style variables in a path string.
+ * Supported variables:
+ * - ${userHome} - User's home directory
+ * - ${workspaceFolder} - Full path of the workspace folder (requires workspaceFolder param)
+ * - ${workspaceFolderBasename} - Name of the workspace folder (requires workspaceFolder param)
+ * - ${repositoryName} - Name of the git repository (requires repositoryName param)
+ *
+ * Also converts relative paths to absolute paths based on workspaceFolder.
+ */
+/**
+ * Sanitizes a branch name for use in filesystem paths.
+ * Replaces forward slashes with a special delimiter to avoid nested directories.
+ * e.g., "feat/abc" becomes "feat__abc"
+ */
+export const sanitizeBranchNameForPath = (branchName: string): string => {
+    return branchName.replace(/\//g, BRANCH_SLASH_REPLACEMENT);
+};
+
+export const resolvePathVariables = (
+    pathStr: string,
+    workspaceFolder?: string,
+    repositoryName?: string
+): string => {
+    let resolved = pathStr;
+
+    // Resolve ${userHome}
+    const userHome = process.env.HOME || process.env.USERPROFILE || "";
+    resolved = resolved.replace(/\$\{userHome\}/g, userHome);
+
+    // Resolve ${repositoryName} if provided
+    if (repositoryName) {
+        resolved = resolved.replace(/\$\{repositoryName\}/g, repositoryName);
+    }
+
+    // Resolve workspace-related variables if workspaceFolder is provided
+    if (workspaceFolder) {
+        // ${workspaceFolder} - full path
+        resolved = resolved.replace(/\$\{workspaceFolder\}/g, workspaceFolder);
+
+        // ${workspaceFolderBasename} - just the folder name
+        const basename = path.basename(workspaceFolder);
+        resolved = resolved.replace(/\$\{workspaceFolderBasename\}/g, basename);
+
+        // Convert relative paths to absolute paths
+        if (!path.isAbsolute(resolved)) {
+            resolved = path.resolve(workspaceFolder, resolved);
+        }
+    }
+
+    return resolved;
+};

--- a/src/helpers/worktree-init-helpers.test.ts
+++ b/src/helpers/worktree-init-helpers.test.ts
@@ -1,0 +1,399 @@
+import * as fs from "fs";
+import * as path from "path";
+import {
+    parseWorktreeConfig,
+    copyInitFiles,
+    runLifecycleCommands,
+    resolveCommandVariables,
+    executeWorktreeAddHooks,
+    executeWorktreeRemoveHooks,
+    executeWorktreeSwitchHooks,
+} from "./worktree-init-helpers";
+import * as helpers from "./helpers";
+
+jest.mock("vscode");
+jest.mock("./helpers");
+jest.mock("./logger", () => ({
+    default: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    __esModule: true,
+}));
+
+const mockedExecuteCommand = helpers.executeCommand as jest.MockedFunction<
+    typeof helpers.executeCommand
+>;
+
+// Mock fs functions used by the module
+jest.mock("fs", () => {
+    const actual = jest.requireActual("fs");
+    return {
+        ...actual,
+        existsSync: jest.fn(),
+        readFileSync: jest.fn(),
+        createReadStream: jest.fn(),
+        createWriteStream: jest.fn(),
+        promises: {
+            mkdir: jest.fn().mockResolvedValue(undefined),
+        },
+    };
+});
+
+jest.mock("stream", () => ({
+    pipeline: jest.fn((_src, _dest, cb) => cb(null)),
+}));
+
+jest.mock("util", () => {
+    const actual = jest.requireActual("util");
+    return {
+        ...actual,
+        promisify: jest.fn((fn) => {
+            // Return a promisified version that resolves
+            return jest.fn().mockResolvedValue(undefined);
+        }),
+    };
+});
+
+const mockedExistsSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+const mockedReadFileSync = fs.readFileSync as jest.MockedFunction<typeof fs.readFileSync>;
+
+describe("worktree-init-helpers", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("parseWorktreeConfig", () => {
+        it("should return null when file does not exist", () => {
+            mockedExistsSync.mockReturnValue(false);
+
+            const result = parseWorktreeConfig("/fake/workspace");
+
+            expect(result).toBeNull();
+        });
+
+        it("should parse valid YAML with add and remove sections", () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(
+                "add:\n  copy:\n    - .env\n    - .env.local\n  commands:\n    - yarn install\n    - yarn db:generate\nremove:\n  commands:\n    - tmux kill-session -t test || true\n"
+            );
+
+            const result = parseWorktreeConfig("/fake/workspace");
+
+            expect(result).toEqual({
+                add: {
+                    copy: [".env", ".env.local"],
+                    commands: ["yarn install", "yarn db:generate"],
+                },
+                remove: {
+                    commands: ["tmux kill-session -t test || true"],
+                },
+            });
+        });
+
+        it("should parse YAML with only add.copy section", () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("add:\n  copy:\n    - .env\n");
+
+            const result = parseWorktreeConfig("/fake/workspace");
+
+            expect(result).toEqual({ add: { copy: [".env"] } });
+        });
+
+        it("should parse YAML with only add.commands section", () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("add:\n  commands:\n    - yarn install\n");
+
+            const result = parseWorktreeConfig("/fake/workspace");
+
+            expect(result).toEqual({ add: { commands: ["yarn install"] } });
+        });
+
+        it("should parse YAML with only remove section", () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("remove:\n  commands:\n    - echo cleanup\n");
+
+            const result = parseWorktreeConfig("/fake/workspace");
+
+            expect(result).toEqual({ remove: { commands: ["echo cleanup"] } });
+        });
+
+        it("should return null for invalid YAML", () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockImplementation(() => {
+                throw new Error("invalid yaml");
+            });
+
+            const result = parseWorktreeConfig("/fake/workspace");
+
+            expect(result).toBeNull();
+        });
+
+        it("should return null for empty file", () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("");
+
+            const result = parseWorktreeConfig("/fake/workspace");
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe("resolveCommandVariables", () => {
+        const originalEnv = process.env;
+
+        beforeEach(() => {
+            process.env = { ...originalEnv, HOME: "/home/testuser" };
+        });
+
+        afterEach(() => {
+            process.env = originalEnv;
+        });
+
+        it("should replace ${userHome}", () => {
+            const result = resolveCommandVariables(
+                "echo ${userHome}",
+                "/worktrees/feat-x",
+                "/workspace/my-repo"
+            );
+            expect(result).toBe("echo /home/testuser");
+        });
+
+        it("should replace ${workspaceFolder} with worktree path", () => {
+            const result = resolveCommandVariables(
+                "cd ${workspaceFolder}",
+                "/worktrees/feat-x",
+                "/workspace/my-repo"
+            );
+            expect(result).toBe("cd /worktrees/feat-x");
+        });
+
+        it("should replace ${workspaceFolderBasename} with worktree folder name", () => {
+            const result = resolveCommandVariables(
+                "echo ${workspaceFolderBasename}",
+                "/worktrees/feat-x",
+                "/workspace/my-repo"
+            );
+            expect(result).toBe("echo feat-x");
+        });
+
+        it("should replace ${repositoryName} with origin repo name", () => {
+            const result = resolveCommandVariables(
+                "echo ${repositoryName}",
+                "/worktrees/feat-x",
+                "/workspace/my-repo"
+            );
+            expect(result).toBe("echo my-repo");
+        });
+
+        it("should replace multiple variables in one command", () => {
+            const result = resolveCommandVariables(
+                "tmux new-session -d -s ${repositoryName} -n ${workspaceFolderBasename} -c ${workspaceFolder}",
+                "/worktrees/feat-x",
+                "/workspace/my-repo"
+            );
+            expect(result).toBe("tmux new-session -d -s my-repo -n feat-x -c /worktrees/feat-x");
+        });
+
+        it("should return command unchanged when no variables present", () => {
+            const result = resolveCommandVariables(
+                "yarn install",
+                "/worktrees/feat-x",
+                "/workspace/my-repo"
+            );
+            expect(result).toBe("yarn install");
+        });
+    });
+
+    describe("copyInitFiles", () => {
+        it("should skip when no add.copy files configured", async () => {
+            await copyInitFiles({ add: { commands: ["yarn install"] } }, "/source", "/target");
+
+            expect(mockedExistsSync).not.toHaveBeenCalled();
+        });
+
+        it("should skip when config has no add section", async () => {
+            await copyInitFiles({ remove: { commands: ["echo bye"] } }, "/source", "/target");
+
+            expect(mockedExistsSync).not.toHaveBeenCalled();
+        });
+
+        it("should skip missing source files with warning", async () => {
+            mockedExistsSync.mockReturnValue(false);
+
+            await copyInitFiles({ add: { copy: [".env"] } }, "/source", "/target");
+
+            expect(mockedExistsSync).toHaveBeenCalledWith(path.join("/source", ".env"));
+        });
+    });
+
+    describe("runLifecycleCommands", () => {
+        it("should skip when commands array is empty", async () => {
+            await runLifecycleCommands([], "/worktree", "/workspace", "Test");
+
+            expect(mockedExecuteCommand).not.toHaveBeenCalled();
+        });
+
+        it("should run commands sequentially in correct cwd with variable substitution", async () => {
+            mockedExecuteCommand.mockResolvedValue({ stdout: "" });
+
+            await runLifecycleCommands(
+                ["yarn install", "yarn db:generate"],
+                "/worktree",
+                "/workspace",
+                "Running worktree add hooks"
+            );
+
+            expect(mockedExecuteCommand).toHaveBeenCalledTimes(2);
+            expect(mockedExecuteCommand).toHaveBeenNthCalledWith(1, "yarn install", {
+                cwd: "/worktree",
+            });
+            expect(mockedExecuteCommand).toHaveBeenNthCalledWith(2, "yarn db:generate", {
+                cwd: "/worktree",
+            });
+        });
+
+        it("should continue running remaining commands when one fails", async () => {
+            mockedExecuteCommand
+                .mockRejectedValueOnce(new Error("command failed"))
+                .mockResolvedValueOnce({ stdout: "" });
+
+            await runLifecycleCommands(
+                ["bad-command", "yarn install"],
+                "/worktree",
+                "/workspace",
+                "Running worktree add hooks"
+            );
+
+            expect(mockedExecuteCommand).toHaveBeenCalledTimes(2);
+        });
+
+        it("should show progress with correct title", async () => {
+            const vscode = require("vscode");
+            mockedExecuteCommand.mockResolvedValue({ stdout: "" });
+
+            await runLifecycleCommands(
+                ["yarn install"],
+                "/worktree",
+                "/workspace",
+                "Running worktree remove hooks"
+            );
+
+            expect(vscode.window.withProgress).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    location: vscode.ProgressLocation.Notification,
+                    title: "Running worktree remove hooks",
+                }),
+                expect.any(Function)
+            );
+        });
+    });
+
+    describe("executeWorktreeAddHooks", () => {
+        it("should silently skip when no config file exists", async () => {
+            mockedExistsSync.mockReturnValue(false);
+
+            await executeWorktreeAddHooks("/workspace", "/new-worktree");
+
+            expect(mockedExecuteCommand).not.toHaveBeenCalled();
+        });
+
+        it("should parse config and run add commands when config exists", async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("add:\n  commands:\n    - yarn install\n");
+            mockedExecuteCommand.mockResolvedValue({ stdout: "" });
+
+            await executeWorktreeAddHooks("/workspace", "/new-worktree");
+
+            expect(mockedExecuteCommand).toHaveBeenCalledWith("yarn install", {
+                cwd: "/new-worktree",
+            });
+        });
+
+        it("should skip commands when config has no add section", async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("remove:\n  commands:\n    - echo bye\n");
+
+            await executeWorktreeAddHooks("/workspace", "/new-worktree");
+
+            expect(mockedExecuteCommand).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("executeWorktreeRemoveHooks", () => {
+        it("should silently skip when no config file exists", async () => {
+            mockedExistsSync.mockReturnValue(false);
+
+            await executeWorktreeRemoveHooks("/workspace", "/worktree");
+
+            expect(mockedExecuteCommand).not.toHaveBeenCalled();
+        });
+
+        it("should run remove commands when config exists", async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("remove:\n  commands:\n    - echo cleanup\n");
+            mockedExecuteCommand.mockResolvedValue({ stdout: "" });
+
+            await executeWorktreeRemoveHooks("/workspace", "/worktree");
+
+            expect(mockedExecuteCommand).toHaveBeenCalledWith("echo cleanup", {
+                cwd: "/worktree",
+            });
+        });
+
+        it("should skip when config has no remove section", async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("add:\n  commands:\n    - yarn install\n");
+
+            await executeWorktreeRemoveHooks("/workspace", "/worktree");
+
+            expect(mockedExecuteCommand).not.toHaveBeenCalled();
+        });
+
+        it("should not block on failure", async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("remove:\n  commands:\n    - failing-cmd\n");
+            mockedExecuteCommand.mockRejectedValue(new Error("cmd failed"));
+
+            // Should not throw
+            await executeWorktreeRemoveHooks("/workspace", "/worktree");
+        });
+    });
+
+    describe("executeWorktreeSwitchHooks", () => {
+        it("should silently skip when no config file exists", async () => {
+            mockedExistsSync.mockReturnValue(false);
+
+            await executeWorktreeSwitchHooks("/workspace", "/worktree");
+
+            expect(mockedExecuteCommand).not.toHaveBeenCalled();
+        });
+
+        it("should run switch commands when config exists", async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("switch:\n  commands:\n    - echo switching\n");
+            mockedExecuteCommand.mockResolvedValue({ stdout: "" });
+
+            await executeWorktreeSwitchHooks("/workspace", "/worktree");
+
+            expect(mockedExecuteCommand).toHaveBeenCalledWith("echo switching", {
+                cwd: "/worktree",
+            });
+        });
+
+        it("should skip when config has no switch section", async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("add:\n  commands:\n    - yarn install\n");
+
+            await executeWorktreeSwitchHooks("/workspace", "/worktree");
+
+            expect(mockedExecuteCommand).not.toHaveBeenCalled();
+        });
+
+        it("should not block on failure", async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue("switch:\n  commands:\n    - failing-cmd\n");
+            mockedExecuteCommand.mockRejectedValue(new Error("cmd failed"));
+
+            // Should not throw
+            await executeWorktreeSwitchHooks("/workspace", "/worktree");
+        });
+    });
+});

--- a/src/helpers/worktree-init-helpers.ts
+++ b/src/helpers/worktree-init-helpers.ts
@@ -1,0 +1,232 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import * as yaml from "js-yaml";
+import { createReadStream, createWriteStream, promises } from "fs";
+import { promisify } from "util";
+import { pipeline as pipelineCallback } from "stream";
+
+import { executeCommand } from "./helpers";
+import logger from "./logger";
+import { WORKTREE_CONFIG_FILENAME } from "../constants/constants";
+
+const pipeline = promisify(pipelineCallback);
+
+export interface WorktreeLifecycleConfig {
+    add?: { copy?: string[]; commands?: string[] };
+    remove?: { commands?: string[] };
+    switch?: { commands?: string[] };
+}
+
+export function parseWorktreeConfig(workspaceFolder: string): WorktreeLifecycleConfig | null {
+    const configPath = path.join(workspaceFolder, WORKTREE_CONFIG_FILENAME);
+
+    if (!fs.existsSync(configPath)) {
+        logger.debug(`No ${WORKTREE_CONFIG_FILENAME} found in ${workspaceFolder}`);
+        return null;
+    }
+
+    try {
+        const content = fs.readFileSync(configPath, "utf-8");
+        const parsed = yaml.load(content) as WorktreeLifecycleConfig;
+
+        if (!parsed || typeof parsed !== "object") {
+            logger.warn(`${WORKTREE_CONFIG_FILENAME} is empty or invalid`);
+            return null;
+        }
+
+        return parsed;
+    } catch (e: any) {
+        logger.warn(`Failed to parse ${WORKTREE_CONFIG_FILENAME}: ${e.message}`);
+        return null;
+    }
+}
+
+export function resolveCommandVariables(
+    command: string,
+    worktreePath: string,
+    workspaceFolder: string
+): string {
+    let resolved = command;
+
+    const userHome = process.env.HOME || process.env.USERPROFILE || "";
+    resolved = resolved.replace(/\$\{userHome\}/g, userHome);
+
+    // ${workspaceFolder} resolves to the worktree path (the actual workspace)
+    resolved = resolved.replace(/\$\{workspaceFolder\}/g, worktreePath);
+
+    // ${workspaceFolderBasename} resolves to the worktree folder name
+    const basename = path.basename(worktreePath);
+    resolved = resolved.replace(/\$\{workspaceFolderBasename\}/g, basename);
+
+    // ${repositoryName} resolves to the origin repository name
+    const repositoryName = path.basename(workspaceFolder);
+    resolved = resolved.replace(/\$\{repositoryName\}/g, repositoryName);
+
+    return resolved;
+}
+
+export async function copyInitFiles(
+    config: WorktreeLifecycleConfig,
+    sourceFolder: string,
+    targetFolder: string
+): Promise<void> {
+    const files = config.add?.copy;
+    if (!files || files.length === 0) {
+        return;
+    }
+
+    for (const file of files) {
+        const sourcePath = path.join(sourceFolder, file);
+        const targetPath = path.join(targetFolder, file);
+
+        if (!fs.existsSync(sourcePath)) {
+            logger.warn(`Init copy: source file not found, skipping: ${sourcePath}`);
+            continue;
+        }
+
+        try {
+            const targetDir = path.dirname(targetPath);
+            await promises.mkdir(targetDir, { recursive: true });
+            await pipeline(createReadStream(sourcePath), createWriteStream(targetPath));
+            logger.debug(`Init copy: ${file} copied to new worktree`);
+        } catch (e: any) {
+            logger.warn(`Init copy: failed to copy ${file}: ${e.message}`);
+        }
+    }
+}
+
+export async function runLifecycleCommands(
+    commands: string[],
+    cwd: string,
+    workspaceFolder: string,
+    title: string
+): Promise<void> {
+    if (commands.length === 0) {
+        return;
+    }
+
+    await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            title,
+            cancellable: false,
+        },
+        async (progress) => {
+            for (let i = 0; i < commands.length; i++) {
+                const rawCmd = commands[i];
+                const cmd = resolveCommandVariables(rawCmd, cwd, workspaceFolder);
+                progress.report({
+                    message: `(${i + 1}/${commands.length}) ${cmd}`,
+                    increment: 100 / commands.length,
+                });
+
+                try {
+                    logger.debug(`Lifecycle command: running '${cmd}' in ${cwd}`);
+                    await executeCommand(cmd, { cwd });
+                    logger.debug(`Lifecycle command: '${cmd}' completed`);
+                } catch (e: any) {
+                    logger.warn(`Lifecycle command failed: '${cmd}': ${e.message}`);
+                    vscode.window.showWarningMessage(
+                        `Worktree lifecycle command failed: '${cmd}'. ${e.message}`
+                    );
+                }
+            }
+        }
+    );
+}
+
+export async function executeWorktreeAddHooks(
+    workspaceFolder: string,
+    newWorktreePath: string
+): Promise<void> {
+    const config = parseWorktreeConfig(workspaceFolder);
+    if (!config) {
+        return;
+    }
+
+    logger.info(`Found ${WORKTREE_CONFIG_FILENAME}, executing add hooks`);
+
+    try {
+        await copyInitFiles(config, workspaceFolder, newWorktreePath);
+
+        const commands = config.add?.commands;
+        if (commands && commands.length > 0) {
+            await runLifecycleCommands(
+                commands,
+                newWorktreePath,
+                workspaceFolder,
+                "Running worktree add hooks"
+            );
+        }
+
+        logger.info("Worktree add hooks completed");
+    } catch (e: any) {
+        logger.warn(`Worktree add hooks error: ${e.message}`);
+        vscode.window.showWarningMessage(`Worktree add hooks encountered an error: ${e.message}`);
+    }
+}
+
+export async function executeWorktreeRemoveHooks(
+    workspaceFolder: string,
+    worktreePath: string
+): Promise<void> {
+    const config = parseWorktreeConfig(workspaceFolder);
+    if (!config) {
+        return;
+    }
+
+    const commands = config.remove?.commands;
+    if (!commands || commands.length === 0) {
+        return;
+    }
+
+    logger.info(`Found ${WORKTREE_CONFIG_FILENAME}, executing remove hooks`);
+
+    try {
+        await runLifecycleCommands(
+            commands,
+            worktreePath,
+            workspaceFolder,
+            "Running worktree remove hooks"
+        );
+        logger.info("Worktree remove hooks completed");
+    } catch (e: any) {
+        logger.warn(`Worktree remove hooks error: ${e.message}`);
+        vscode.window.showWarningMessage(
+            `Worktree remove hooks encountered an error: ${e.message}`
+        );
+    }
+}
+
+export async function executeWorktreeSwitchHooks(
+    workspaceFolder: string,
+    worktreePath: string
+): Promise<void> {
+    const config = parseWorktreeConfig(workspaceFolder);
+    if (!config) {
+        return;
+    }
+
+    const commands = config.switch?.commands;
+    if (!commands || commands.length === 0) {
+        return;
+    }
+
+    logger.info(`Found ${WORKTREE_CONFIG_FILENAME}, executing switch hooks`);
+
+    try {
+        await runLifecycleCommands(
+            commands,
+            worktreePath,
+            workspaceFolder,
+            "Running worktree switch hooks"
+        );
+        logger.info("Worktree switch hooks completed");
+    } catch (e: any) {
+        logger.warn(`Worktree switch hooks error: ${e.message}`);
+        vscode.window.showWarningMessage(
+            `Worktree switch hooks encountered an error: ${e.message}`
+        );
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,6 +1208,11 @@
     jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
+"@types/js-yaml@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
+
 "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -3843,6 +3848,13 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -5888,7 +5900,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5920,7 +5941,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6410,7 +6438,7 @@ workerpool@6.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.0.tgz#827d93c9ba23ee2019c3ffaff5c27fccea289e8b"
   integrity sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -6423,6 +6451,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary
- Add support for VS Code-style path variables in the `worktrees.dir.path` setting
- Enable dynamic path resolution for more flexible worktree directory configuration
- Support relative paths that are resolved from the workspace folder

## Changes
- **package.json**: Updated setting description to document supported variables
- **src/helpers/helpers.ts**: Added `resolvePathVariables()` function supporting:
  - `${userHome}` - User's home directory
  - `${workspaceFolder}` - Full workspace path
  - `${workspaceFolderBasename}` - Workspace folder name
  - `${repositoryName}` - Git repository name
- **src/helpers/gitWorktreeHelpers.ts**: Integrated path variable resolution in `calculateNewWorktreePath()`

## Test plan
- [x] Verify `${userHome}` resolves to user home directory
- [x] Verify `${repositoryName}` resolves to current git repository name
- [x] Verify `${workspaceFolderBasename}` resolves to workspace folder name
- [x] Verify relative paths are converted to absolute paths
- [x] Test combined variables like `${userHome}/worktrees/${repositoryName}`